### PR TITLE
Feat/notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ buildNumber.properties
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
+my-app/.env

--- a/my-app/pom.xml
+++ b/my-app/pom.xml
@@ -40,6 +40,34 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+    
+    <!-- Jetty Server dependencies -->
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <version>9.4.51.v20230217</version>
+    </dependency>
+    
+    <!-- JSON processing -->
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20231013</version>
+    </dependency>
+
+    <!-- Servlet API -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>4.0.1</version>
+    </dependency>
+    
+    <!-- Dotenv -->
+    <dependency>
+      <groupId>io.github.cdimascio</groupId>
+      <artifactId>dotenv-java</artifactId>
+      <version>3.0.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/my-app/src/main/java/com/group16/app/ContinuousIntegrationServer.java
+++ b/my-app/src/main/java/com/group16/app/ContinuousIntegrationServer.java
@@ -39,12 +39,13 @@ public class ContinuousIntegrationServer extends AbstractHandler
 
         // 4th notify the result        
         String payload = request.getParameter("payload");
+        String requestURL = request.getRequestURL().toString();
         JSONObject json = new JSONObject(payload);
         String owner = json.getJSONObject("repository").getJSONObject("owner").getString("login");
         String repo = json.getJSONObject("repository").getString("name");
         String commitSha = json.getString("after");
 
-        Notification.sendNotification(Status.PENDING, owner, repo, commitSha);
+        Notification.sendNotification(Status.PENDING, requestURL, owner, repo, commitSha);
         
         response.getWriter().println("CI job done");
     }

--- a/my-app/src/main/java/com/group16/app/ContinuousIntegrationServer.java
+++ b/my-app/src/main/java/com/group16/app/ContinuousIntegrationServer.java
@@ -1,3 +1,4 @@
+package com.group16.app;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.ServletException;
@@ -7,6 +8,8 @@ import java.io.IOException;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
+
+import org.json.JSONObject;
 
 /** 
  Skeleton of a ContinuousIntegrationServer which acts as webhook
@@ -31,6 +34,18 @@ public class ContinuousIntegrationServer extends AbstractHandler
         // 1st clone your repository
         // 2nd compile the code
 
+
+        // 3rd run test
+
+        // 4th notify the result        
+        String payload = request.getParameter("payload");
+        JSONObject json = new JSONObject(payload);
+        String owner = json.getJSONObject("repository").getJSONObject("owner").getString("login");
+        String repo = json.getJSONObject("repository").getString("name");
+        String commitSha = json.getString("after");
+
+        Notification.sendNotification(Status.PENDING, owner, repo, commitSha);
+        
         response.getWriter().println("CI job done");
     }
  

--- a/my-app/src/main/java/com/group16/app/Notification.java
+++ b/my-app/src/main/java/com/group16/app/Notification.java
@@ -6,20 +6,40 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import io.github.cdimascio.dotenv.Dotenv;
 
+/**
+ * Notification class to send status notifications to GitHub for a given commit.
+ * 
+ * Note: GITHUB_PAT is a Personal Access Token (PAT) for the GitHub API, which
+ * needs to be stored in a .env file.
+ */
 public class Notification {
     private static final String GITHUB_API_URL = "https://api.github.com";
     private static final Dotenv dotenv = Dotenv.load();
     private static final String GITHUB_PAT = dotenv.get("GITHUB_PAT");
 
-    public static void sendNotification(Status status, String owner, String repo, String commitSha) {
+    /**
+     * Sends a notification to GitHub about the build/test status of a commit.
+     * This method creates and sends a POST request to the GitHub API to update the
+     * status of a specific commit.
+     *
+     * @param status     The build/test status (SUCCESS, FAILURE, ERROR or PENDING)
+     *                   to be reported to GitHub
+     * @param requestURL The URL for more information about the build/test
+     * @param owner      The owner (user or organization) of the GitHub repository
+     * @param repo       The name of the GitHub repository
+     * @param commitSha  The SHA hash of the commit to update the status for
+     */
+    public static void sendNotification(Status status, String requestURL, String owner, String repo, String commitSha)
+            throws RuntimeException {
         String body = String.format("""
                 {
                     "state": "%s",
-                    "target_url": "http://ci-server.example.com/build/123",
+                    "target_url": "%s",
                     "description": "%s",
                     "context": "continuous-integration/jetty"
                 }""",
                 status.toString().toLowerCase(),
+                requestURL,
                 status == Status.SUCCESS ? "Build succeeded" : "Build failed");
 
         String url = String.format("%s/repos/%s/%s/statuses/%s", GITHUB_API_URL, owner, repo, commitSha);
@@ -35,9 +55,17 @@ public class Notification {
 
         try {
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            System.out.println("GitHub Response: " + response.statusCode() + " - " + response.body());
+            System.out.println(String.format("GitHub Response for %s: %d - %s",
+                    request.method(), response.statusCode(), response.body()));
+
+            if (response.statusCode() != 201) { // GitHub API returns 201 for successful POST requests
+                throw new RuntimeException("Failed to send notification to GitHub. Status code: " +
+                        response.statusCode() + ", Response: " + response.body());
+            }
         } catch (Exception e) {
-            e.printStackTrace();
+            // Print error message to stderr and rethrow as a RuntimeException
+            System.err.println("Error sending GitHub notification: " + e.getMessage());
+            throw new RuntimeException("Failed to update GitHub status to " + status.toString().toLowerCase(), e);
         }
     }
 

--- a/my-app/src/main/java/com/group16/app/Notification.java
+++ b/my-app/src/main/java/com/group16/app/Notification.java
@@ -1,0 +1,44 @@
+package com.group16.app;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import io.github.cdimascio.dotenv.Dotenv;
+
+public class Notification {
+    private static final String GITHUB_API_URL = "https://api.github.com";
+    private static final Dotenv dotenv = Dotenv.load();
+    private static final String GITHUB_PAT = dotenv.get("GITHUB_PAT");
+
+    public static void sendNotification(Status status, String owner, String repo, String commitSha) {
+        String body = String.format("""
+                {
+                    "state": "%s",
+                    "target_url": "http://ci-server.example.com/build/123",
+                    "description": "%s",
+                    "context": "continuous-integration/jetty"
+                }""",
+                status.toString().toLowerCase(),
+                status == Status.SUCCESS ? "Build succeeded" : "Build failed");
+
+        String url = String.format("%s/repos/%s/%s/statuses/%s", GITHUB_API_URL, owner, repo, commitSha);
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Authorization", "Bearer " + GITHUB_PAT)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+
+        HttpClient client = HttpClient.newHttpClient();
+
+        try {
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            System.out.println("GitHub Response: " + response.statusCode() + " - " + response.body());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/my-app/src/main/java/com/group16/app/Status.java
+++ b/my-app/src/main/java/com/group16/app/Status.java
@@ -1,0 +1,5 @@
+package com.group16.app;
+
+public enum Status {
+    SUCCESS, FAILURE, ERROR, PENDING
+}

--- a/my-app/src/test/java/com/group16/app/NotificationTest.java
+++ b/my-app/src/test/java/com/group16/app/NotificationTest.java
@@ -1,0 +1,123 @@
+package com.group16.app;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.cdimascio.dotenv.Dotenv;
+
+/**
+ * Unit test for the Notification class.
+ */
+public class NotificationTest {
+    // This commit being tested has the message:
+    // "feat: begin implementing notifications class".
+    // And can be found at:
+    // https://github.com/DD2480-group16-VT25/continuous-integration/commit/028d21cf77074ac45a320b0275911a7da9a32c87
+    private static final String commitSha = "028d21cf77074ac45a320b0275911a7da9a32c87";
+    private static final String repo = "continuous-integration";
+    private static final String owner = "DD2480-group16-VT25";
+    private static final String requestURL = "https://api.github.com/repos/DD2480-group16-VT25/continuous-integration/statuses/028d21cf77074ac45a320b0275911a7da9a32c87";
+    private static final Dotenv dotenv = Dotenv.load();
+    private static final String GITHUB_PAT = dotenv.get("GITHUB_PAT");
+    private static final String url = String.format("https://api.github.com/repos/%s/%s/statuses/%s", owner, repo,
+            commitSha);
+
+    /**
+     * Get the status of a commit from the GitHub API.
+     *
+     * @return The status of the commit
+     */
+    private static Status getStatus() {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Authorization", "Bearer " + GITHUB_PAT)
+                .header("Content-Type", "application/json")
+                .GET()
+                .build();
+
+        HttpClient client = HttpClient.newHttpClient();
+
+        String state;
+        try {
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            // Convert HTTP response body to JSON array and get first status
+            String responseBody = response.body();
+            if (responseBody.startsWith("[")) {
+                JSONObject json = new JSONObject(responseBody.substring(1, responseBody.length() - 1));
+                state = json.getString("state");
+            } else {
+                JSONObject json = new JSONObject(responseBody);
+                state = json.getString("state");
+            }
+
+            System.out.println(String.format("GitHub Response for %s: %d - %s",
+                    request.method(), response.statusCode(), state));
+        } catch (Exception e) {
+            e.printStackTrace();
+            return Status.ERROR;
+        }
+
+        return Status.valueOf(state.toUpperCase()); // Convert to Status enum
+    }
+
+    /**
+     * (Re)set the commit status to PENDING before each test.
+     */
+    @BeforeEach
+    public void setup() {
+        Notification.sendNotification(Status.PENDING, requestURL, owner, repo, commitSha);
+        assertEquals(getStatus(), Status.PENDING); // Implicitly tests the case of PENDING status
+    }
+
+    @Test
+    public void setStatusSuccess() {
+        Notification.sendNotification(Status.SUCCESS, requestURL, owner, repo, commitSha);
+        assertEquals(getStatus(), Status.SUCCESS);
+    }
+
+    @Test
+    public void setStatusFailure() {
+        Notification.sendNotification(Status.FAILURE, requestURL, owner, repo, commitSha);
+        assertEquals(getStatus(), Status.FAILURE);
+    }
+
+    @Test
+    public void setStatusError() {
+        Notification.sendNotification(Status.ERROR, requestURL, owner, repo, commitSha);
+        assertEquals(getStatus(), Status.ERROR);
+    }
+
+    @Test
+    public void invalidOwnerThrowsException() {
+        String invalidOwner = "invalid-owner";
+        assertThrows(RuntimeException.class, () -> {
+            Notification.sendNotification(Status.SUCCESS, requestURL, invalidOwner, repo, commitSha);
+        });
+    }
+
+    @Test
+    public void invalidRepoThrowsException() {
+        String invalidRepo = "invalid-repo";
+        assertThrows(RuntimeException.class, () -> {
+            Notification.sendNotification(Status.SUCCESS, requestURL, owner, invalidRepo, commitSha);
+        });
+    }
+
+    @Test
+    public void invalidCommitShaThrowsException() {
+        String invalidCommitSha = "invalid-sha";
+        assertThrows(RuntimeException.class, () -> {
+            Notification.sendNotification(Status.SUCCESS, requestURL, owner, repo, invalidCommitSha);
+        });
+    }
+}


### PR DESCRIPTION
**You currently need a PAT github API key for local testing**. Add yours or ask for mine and add to a `.env` file in `my-app` as `GITHUB_PAT=XXXXX`.

Adds a Notification class with a static method for changing the status of a commit using its commit SHA. The method is unit tested for all different statuses and exceptions for invalid inputs (`requestURL` parameter isn't tested since it doesn't affect the functionality).